### PR TITLE
hackvmの細かい仕様を標準に合わせる

### DIFF
--- a/hackvm/codewriter/codewriter.go
+++ b/hackvm/codewriter/codewriter.go
@@ -52,13 +52,5 @@ M=D
 	if err := c.WriteCall("Sys.init", 0); err != nil {
 		return err
 	}
-	terminateCode := `// termination
-(TERMINATE)
-@TERMINATE
-0;JMP
-`
-	if _, err := fmt.Fprint(c.out, terminateCode); err != nil {
-		return errors.WithStack(err)
-	}
 	return nil
 }

--- a/hackvm/codewriter/codewriter.go
+++ b/hackvm/codewriter/codewriter.go
@@ -12,13 +12,17 @@ type CodeWriter struct {
 	out             io.Writer
 	comparisonIndex int
 	fileName        string
+	currentFuncName string
 	callCount       int // how many times "call f n" command are written
 }
 
 //出力ファイル/ストリームを開き書き込む準備を行う
 func New(w io.Writer) *CodeWriter {
 	return &CodeWriter{
-		out: w,
+		// WriteLabel, WriteGoto, WriteIfの単体テストで用いるための仮の関数名
+		// 実際のVMコードではなんらかのfunctionの内部にしかbranching命令が書かれない
+		currentFuncName: "global",
+		out:             w,
 	}
 }
 

--- a/hackvm/codewriter/codewriter_function_call.go
+++ b/hackvm/codewriter/codewriter_function_call.go
@@ -9,7 +9,7 @@ import (
 func (c *CodeWriter) WriteFunction(funcName string, numLocal int) error {
 	c.currentFuncName = funcName // label, goto, if-gotoコマンドのために必要
 	format := `// function %[1]s %[2]d
-(function_%[1]s)
+(%[1]s)
 `
 	initializeDRegister := `@0
 D=A
@@ -174,7 +174,7 @@ D=M
 @LCL
 M=D
 // goto %[1]s
-@function_%[1]s
+@%[1]s
 0;JMP
 (return_address_%[4]d)
 `

--- a/hackvm/codewriter/codewriter_function_call.go
+++ b/hackvm/codewriter/codewriter_function_call.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (c *CodeWriter) WriteFunction(funcName string, numLocal int) error {
+	c.currentFuncName = funcName // label, goto, if-gotoコマンドのために必要
 	format := `// function %[1]s %[2]d
 (function_%[1]s)
 `

--- a/hackvm/codewriter/codewriter_function_call_test.go
+++ b/hackvm/codewriter/codewriter_function_call_test.go
@@ -21,7 +21,7 @@ func TestWriteFunctionDeclaration(t *testing.T) {
 			numLocals: 3,
 			fileName:  "Test.vm",
 			want: `// function f 3
-(function_f)
+(f)
 @0
 D=A
 @SP
@@ -224,7 +224,7 @@ D=M
 @LCL
 M=D
 // goto f
-@function_f
+@f
 0;JMP
 (return_address_0)
 `,

--- a/hackvm/codewriter/codewriter_program_flow.go
+++ b/hackvm/codewriter/codewriter_program_flow.go
@@ -13,9 +13,9 @@ func (c *CodeWriter) WriteLabel(label string) error {
 		return err
 	}
 	format := `// label %[1]s
-(label_%[2]s_%[1]s)
+(%[1]s)
 `
-	if _, err := fmt.Fprintf(c.out, format, label, c.fileName); err != nil {
+	if _, err := fmt.Fprintf(c.out, format, c.currentFuncName+"$"+label); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil
@@ -27,10 +27,10 @@ func (c *CodeWriter) WriteGoto(label string) error {
 		return err
 	}
 	format := `// goto %[1]s
-@label_%[2]s_%[1]s
+@%[1]s
 0;JMP
 `
-	if _, err := fmt.Fprintf(c.out, format, label, c.fileName); err != nil {
+	if _, err := fmt.Fprintf(c.out, format, c.generateLabel(label)); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil
@@ -46,10 +46,10 @@ func (c *CodeWriter) WriteIf(label string) error {
 M=M-1
 A=M
 D=M
-@label_%[2]s_%[1]s
+@%[1]s
 D;JNE
 `
-	if _, err := fmt.Fprintf(c.out, format, label, c.fileName); err != nil {
+	if _, err := fmt.Fprintf(c.out, format, c.generateLabel(label)); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil
@@ -63,4 +63,8 @@ func (c *CodeWriter) validateLabel(label string) error {
 		return errors.Errorf("invalid label %q", label)
 	}
 	return nil
+}
+
+func (c *CodeWriter) generateLabel(label string) string {
+	return c.currentFuncName + "$" + label
 }

--- a/hackvm/codewriter/codewriter_program_flow_test.go
+++ b/hackvm/codewriter/codewriter_program_flow_test.go
@@ -19,15 +19,15 @@ func TestWriteLabel(t *testing.T) {
 		{
 			label:    "xyz",
 			fileName: "Test1.vm",
-			want: `// label xyz
-(label_Test1_xyz)
+			want: `// label global$xyz
+(global$xyz)
 `,
 		},
 		{
 			label:    "x_.:123",
 			fileName: "Test.vm",
-			want: `// label x_.:123
-(label_Test_x_.:123)
+			want: `// label global$x_.:123
+(global$x_.:123)
 `,
 		},
 		{
@@ -75,8 +75,8 @@ func TestWriteGoto(t *testing.T) {
 		{
 			label:    "xyz",
 			fileName: "Test1.vm",
-			want: `// goto xyz
-@label_Test1_xyz
+			want: `// goto global$xyz
+@global$xyz
 0;JMP
 `,
 		},
@@ -116,12 +116,12 @@ func TestWriteIf(t *testing.T) {
 		{
 			label:    "xyz",
 			fileName: "Test1.vm",
-			want: `// if-goto xyz
+			want: `// if-goto global$xyz
 @SP
 M=M-1
 A=M
 D=M
-@label_Test1_xyz
+@global$xyz
 D;JNE
 `,
 		},

--- a/hackvm/hackvm.go
+++ b/hackvm/hackvm.go
@@ -52,6 +52,9 @@ func exec() error {
 		cw.Init()
 
 		for _, src := range dir {
+			if filepath.Ext(src.Name()) != "vm" {
+				continue
+			}
 			if err := func() error {
 				src, err := os.Open(filepath.Join(arg, src.Name()))
 				if err != nil {
@@ -70,7 +73,7 @@ func exec() error {
 		return nil
 	}
 
-	vmFile, err := os.Open(args[0])
+	vmFile, err := os.Open(arg)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
- labelコマンドの標準マッピングに従う
- ディレクトリと単一ファイルで扱いを変える
- 不要なterminate codeの削除
- .vmファイル以外は無視する
- 出力ファイル名を修正する
- function/call命令で生成するラベルを標準マッピングに従わせる

StaticsTestとかが通ることは確認済みです